### PR TITLE
Support removing strings from the index

### DIFF
--- a/src/DataStore/DataStoreInterface.php
+++ b/src/DataStore/DataStoreInterface.php
@@ -6,6 +6,8 @@ interface DataStoreInterface
 {
     public function add(int $state, string $string): void;
 
+    public function remove(int $state, string $string): void;
+
     /**
      * Returns the matching strings per state. Key is the state and the value is an array of matching strings
      * for that state.

--- a/src/DataStore/InMemoryDataStore.php
+++ b/src/DataStore/InMemoryDataStore.php
@@ -14,6 +14,17 @@ class InMemoryDataStore implements DataStoreInterface
         $this->data[$state][] = $string;
     }
 
+    public function remove(int $state, string $string): void
+    {
+        $updated = array_values(array_diff($this->data[$state] ?? [], [$string]));
+
+        if ($updated) {
+            $this->data[$state] = $updated;
+        } else {
+            unset($this->data[$state]);
+        }
+    }
+
     public function all(): array
     {
         return $this->data;

--- a/src/DataStore/NullDataStore.php
+++ b/src/DataStore/NullDataStore.php
@@ -9,6 +9,11 @@ class NullDataStore implements DataStoreInterface
         // noop
     }
 
+    public function remove(int $state, string $string): void
+    {
+        // noop
+    }
+
     public function getForStates(array $states = []): array
     {
         return [];

--- a/src/StateSet/InMemoryStateSet.php
+++ b/src/StateSet/InMemoryStateSet.php
@@ -17,6 +17,11 @@ class InMemoryStateSet implements StateSetInterface
         $this->states[$state] = true;
     }
 
+    public function remove(int $state): void
+    {
+        unset($this->states[$state]);
+    }
+
     public function all(): array
     {
         return array_keys($this->states);

--- a/src/StateSet/StateSetInterface.php
+++ b/src/StateSet/StateSetInterface.php
@@ -6,6 +6,8 @@ interface StateSetInterface
 {
     public function add(int $state): void;
 
+    public function remove(int $state): void;
+
     /**
      * @return array<int>
      */

--- a/tests/StateSetIndexTest.php
+++ b/tests/StateSetIndexTest.php
@@ -62,4 +62,22 @@ class StateSetIndexTest extends TestCase
         $this->assertSame([54091 => ['assassin']], $stateSetIndex->findAcceptedStrings('assasin', 2));
         $this->assertSame(['assassin'], $stateSetIndex->find('assasin', 2));
     }
+
+    public function testRemoveFromIndex(): void
+    {
+        $stateSetIndex = new StateSetIndex(new Config(6, 4), new Utf8Alphabet(), new InMemoryStateSet(), new InMemoryDataStore());
+        $stateSetIndex->index(['Mueller']);
+
+        $onlyMuellerStates = $stateSetIndex->getStateSet()->all();
+
+        $stateSetIndex->removeFromIndex(['Mueller']);
+
+        $this->assertSame([], $stateSetIndex->getStateSet()->all());
+
+        $stateSetIndex->index(['Müller', 'Muentner', 'Muster', 'Mustermann', 'Mueller']);
+        $stateSetIndex->removeFromIndex(['Müller', 'Muentner', 'Muster', 'Mustermann']);
+
+        $this->assertEquals($onlyMuellerStates, $stateSetIndex->getStateSet()->all());
+        $this->assertSame(['Mueller'], $stateSetIndex->find('Mueler', 1));
+    }
 }

--- a/tests/StateSetIndexTest.php
+++ b/tests/StateSetIndexTest.php
@@ -80,4 +80,41 @@ class StateSetIndexTest extends TestCase
         $this->assertEquals($onlyMuellerStates, $stateSetIndex->getStateSet()->all());
         $this->assertSame(['Mueller'], $stateSetIndex->find('Mueler', 1));
     }
+
+    public function testRemoveFromFullIndex(): void
+    {
+        $stateSetIndex = new StateSetIndex(new Config(5, 4), new Utf8Alphabet(), new InMemoryStateSet(), new InMemoryDataStore());
+        $stateSetIndex->index(['Mueller']);
+
+        $onlyMuellerStates = $stateSetIndex->getStateSet()->all();
+
+        $stateSetIndex->removeFromIndex(['Mueller']);
+
+        $this->assertSame([], $stateSetIndex->getStateSet()->all());
+
+        for ($i = 0; $i < $stateSetIndex->getConfig()->getAlphabetSize(); ++$i) {
+            $strings[] = \IntlChar::chr(97 + $i);
+        }
+
+        for ($length = 1; $length <= $stateSetIndex->getConfig()->getIndexLength(); ++$length) {
+            foreach ($strings as $string) {
+                for ($i = 0; $i < $stateSetIndex->getConfig()->getAlphabetSize(); ++$i) {
+                    $strings[] = $string . \IntlChar::chr(97 + $i);
+                }
+            }
+        }
+
+        // Fill every possible state for the configured length and size
+        $stateSetIndex->index($strings);
+        $stateSetIndex->index(['Mueller']);
+
+        $states = $stateSetIndex->getStateSet()->all();
+        sort($states);
+
+        $this->assertSame(range(1, (((4 * 4 + 4) * 4 + 4) * 4 + 4) * 4 + 4), $states, 'No state should be missing');
+
+        $stateSetIndex->removeFromIndex($strings);
+
+        $this->assertEquals($onlyMuellerStates, $stateSetIndex->getStateSet()->all());
+    }
 }


### PR DESCRIPTION
See https://github.com/loupe-php/loupe/issues/112#issuecomment-2500171748

This should be safe as it only deletes states that can never end up in a match anymore (meaning there is no possible path forward from these states and they are not assigned to any strings in the data store).

This is a draft as the interfaces would have to be changed or new ones introduced.