### PR TITLE
Do not apply transposition logic if landing node does not exist

### DIFF
--- a/src/StateSetIndex.php
+++ b/src/StateSetIndex.php
@@ -133,12 +133,15 @@ class StateSetIndex
             // previous char and assigns a combined cost of $transpositionCost.
             foreach (($lastSubstitutions[$mappedChar] ?? null)?->all() ?? [] as $state => $cost) {
                 $newState = (int) ($state * $alphabetSize + $lastMappedChar);
-                $statesStar = $statesStar->mergeWith($this->getReachableStates(
-                    $alphabetSize,
-                    $newState,
-                    $editDistance,
-                    $cost - 1 + $transpositionCost,
-                ));
+
+                if ($this->stateSet->has($newState)) {
+                    $statesStar = $statesStar->mergeWith($this->getReachableStates(
+                        $alphabetSize,
+                        $newState,
+                        $editDistance,
+                        $cost - 1 + $transpositionCost,
+                    ));
+                }
             }
 
             $states = $statesStar;


### PR DESCRIPTION
That should get rid of a few useless states 🤔 